### PR TITLE
Fixing mobile styling for password page

### DIFF
--- a/src/app/password/password.module.css
+++ b/src/app/password/password.module.css
@@ -120,7 +120,7 @@
 
 /* Mobile */
 @media (max-width: 679px) {
-    .modal {
+    /* .modal {
         align-items: end;
     }
 
@@ -129,7 +129,7 @@
         border-bottom-right-radius: 0;
         width: 100%;
         animation: slideUp 0.3s ease-out;
-    }
+    } */
 
     .title {
         font-size: 1.75rem;


### PR DESCRIPTION
Fixed styling on the password page for mobile so it no longer aligns at the bottom.